### PR TITLE
Cambios en iterators.h_MaizoDiego

### DIFF
--- a/iterators.h
+++ b/iterators.h
@@ -1,6 +1,9 @@
 //Añadir # a ifndef por Diego Panta
 #ifndef __ITERATORS_H__
 #define __ITERATORS_H__
+#include <iostream>
+#include <vector>
+#include "type.h" 
 
 template <typename Iterator>
 void recorrer1(Iterator begin, Iterator end, ostream &os)
@@ -34,10 +37,7 @@ void recorrer4(Container &container, Function &function)
 		function(*begin); //eliminado extra_param_MaizoDiego
 }
 
-template <typename T> //creando template - Kevin De Lama
-void incrementar(T &val) //int cambiado por T1 - Kevin De Lama
-{
-	val++;
-}
+void incrementar(T1 &val) //int cambiado por T1 - Kevin De Lama
+{ val++; }
 
 #endif // Agregado por Kevin De Lama


### PR DESCRIPTION
Se elimino el template de la función incrementar, este mismo generaba un error con la funcion recorer2 y recorrer4; debido a que enviaba un valor tipo template.